### PR TITLE
OPS-6649 fix fast-xml-parser vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,9 @@
   "pnpm": {
     "overrides": {
       "lodash": "4.18.1",
-      "serialize-javascript": "7.0.5"
+      "serialize-javascript": "7.0.5",
+      "fast-xml-parser@>=4.1.3 <4.5.4": "4.5.4",
+      "fast-xml-parser@>=5.0.0 <5.3.5": "5.3.5"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,8 @@ settings:
 overrides:
   lodash: 4.18.1
   serialize-javascript: 7.0.5
+  fast-xml-parser@>=4.1.3 <4.5.4: 4.5.4
+  fast-xml-parser@>=5.0.0 <5.3.5: 5.3.5
 
 importers:
 
@@ -1284,8 +1286,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-xml-parser@5.2.5:
-    resolution: {integrity: sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==}
+  fast-xml-parser@5.3.5:
+    resolution: {integrity: sha512-JeaA2Vm9ffQKp9VjvfzObuMCjUYAp5WDYhRYL5LrBPY/jUDlUtOvDfot0vKSkB9tuX885BDHjtw4fZadD95wnA==}
     hasBin: true
 
   file-entry-cache@8.0.0:
@@ -2022,8 +2024,8 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
-  strnum@2.1.1:
-    resolution: {integrity: sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==}
+  strnum@2.3.0:
+    resolution: {integrity: sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==}
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -2547,7 +2549,7 @@ snapshots:
       '@smithy/util-body-length-browser': 4.0.0
       '@smithy/util-middleware': 4.0.5
       '@smithy/util-utf8': 4.0.0
-      fast-xml-parser: 5.2.5
+      fast-xml-parser: 5.3.5
       tslib: 2.8.1
     optional: true
 
@@ -3692,9 +3694,9 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-xml-parser@5.2.5:
+  fast-xml-parser@5.3.5:
     dependencies:
-      strnum: 2.1.1
+      strnum: 2.3.0
     optional: true
 
   file-entry-cache@8.0.0:
@@ -4457,7 +4459,7 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  strnum@2.1.1:
+  strnum@2.3.0:
     optional: true
 
   supports-color@7.2.0:


### PR DESCRIPTION
## Summary
- Fix OPS-6649 Dependabot alert(s): 64
- Add pnpm overrides for vulnerable fast-xml-parser ranges:
  - >=4.1.3 <4.5.4 -> 4.5.4
  - >=5.0.0 <5.3.5 -> 5.3.5
- Refresh pnpm-lock.yaml so vulnerable fast-xml-parser v4/v5 entries are removed

## Validation
- pnpm-lock.yaml parses as YAML
- Local scan found no vulnerable fast-xml-parser v4/v5 entries
- Reviewers: none